### PR TITLE
Feat: 사용자 가이드라인 UI 구현 (#54)

### DIFF
--- a/src/components/common/GuideLine.tsx
+++ b/src/components/common/GuideLine.tsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useRef } from 'react';
+import styled from 'styled-components';
+
+const Guideline: React.FC = () => {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+
+  useEffect(() => {
+    async function setupCamera() {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream;
+        }
+      } catch (error) {
+        console.error("Camera setup failed:", error);
+      }
+    }
+
+    setupCamera();
+  }, []);
+
+  return (
+    <Wrapper>
+      <Container>
+        <VideoContainer>
+        <VideoPlayer ref={videoRef} autoPlay />
+          <Overlay>
+            <Rectangle />
+            <Circle />
+          </Overlay>
+        </VideoContainer>
+        <Text>보다 명확한 피드백을 위해<br/>화면에 맞춰 앉아 주세요!</Text>      
+      </Container>
+
+      <Info>잠시 후 스터디룸에 입장합니다.</Info>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  background-color: ${({ theme }) => theme.colors.background2};
+  justify-content: space-between;
+  padding: 200px 50px 80px;
+  box-sizing: border-box;
+`;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const VideoContainer = styled.div`
+  position: relative;
+  width: 630px;
+  height: 400px;
+  overflow: hidden;
+  border: none;
+  border-radius: 5px;
+`;
+
+const VideoPlayer = styled.video`
+  width: 100%;
+`;
+
+const Overlay = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+`;
+
+const Circle = styled.div`
+  width: 240px;
+  height: 240px;
+  border-radius: 50%;
+  border: 2px solid ${({ theme }) => theme.colors.main};
+  position: absolute;
+  left: 50%;
+  top: 20%;
+  transform: translate(-50%, -19%); // 네모 위로 위치 조정
+`;
+
+const Rectangle = styled.div`
+  width: 300px;
+  height: 120px;
+  border: 2px solid ${({ theme }) => theme.colors.main};
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translate(-50%, 0); // 중앙 정렬
+`;
+
+const Text = styled.div`
+  color: ${({ theme }) => theme.colors.white02};
+  font-size: 32px;
+  font-family: NotoSansSemiBold;
+  margin-top: 20px;
+  text-align: center;
+`;
+
+const Info = styled.div`
+  color: ${({ theme }) => theme.colors.main};
+  font-size: 24px;
+  font-family: NotoSansMedium;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+`;
+
+export default Guideline;

--- a/src/components/common/GuideLine.tsx
+++ b/src/components/common/GuideLine.tsx
@@ -40,12 +40,18 @@ const Guideline: React.FC = () => {
 const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
+  position: absolute;
+  z-index: 100;
   height: 100%;
   width: 100%;
   background-color: ${({ theme }) => theme.colors.background2};
   justify-content: space-between;
   padding: 200px 50px 80px;
   box-sizing: border-box;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
 `;
 
 const Container = styled.div`

--- a/src/components/studySetting/DefaultSetting.tsx
+++ b/src/components/studySetting/DefaultSetting.tsx
@@ -83,7 +83,7 @@ const DefaultSetting: React.FC<DefaultSettingProps> = ({ setSelectedTab, setLoad
     setTimeout(() => {    // 임의의 로딩시간 설정
       setLoading(false);
       navigate('/room/:roomId');
-    }, 10000000);
+    }, 6000);
   };
 
   return (
@@ -129,7 +129,7 @@ const DefaultSetting: React.FC<DefaultSettingProps> = ({ setSelectedTab, setLoad
 
       <Buttons>
         <Button onClick={handlePrevButtonClick}>이전</Button>
-        <Button onClick={handleNextButtonClick}>다음</Button>
+        <Button onClick={handleNextButtonClick} disabled={!cameraPermission}>다음</Button>
       </Buttons>
     </Wrapper>
   );

--- a/src/components/studySetting/DefaultSetting.tsx
+++ b/src/components/studySetting/DefaultSetting.tsx
@@ -6,9 +6,10 @@ import UnSwitch from "../../assets/images/unSwitch.png";
 
 interface DefaultSettingProps {
   setSelectedTab: React.Dispatch<React.SetStateAction<string>>;
+  setLoading: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const DefaultSetting: React.FC<DefaultSettingProps> = ({ setSelectedTab }) => {
+const DefaultSetting: React.FC<DefaultSettingProps> = ({ setSelectedTab, setLoading }) => {
   const [cameraPermission, setCameraPermission] = useState<boolean>(false);
   const [defaultRoomSetting, setDefaultRoomSetting] = useState<boolean>(false);
   const [stream, setStream] = useState<MediaStream | null>(null);
@@ -78,7 +79,11 @@ const DefaultSetting: React.FC<DefaultSettingProps> = ({ setSelectedTab }) => {
   
   const handleNextButtonClick = () => {
     console.log("디폴트 설정: ", defaultRoomSetting);
-    navigate('/room/:roomId');
+    setLoading(true);
+    setTimeout(() => {    // 임의의 로딩시간 설정
+      setLoading(false);
+      navigate('/room/:roomId');
+    }, 10000000);
   };
 
   return (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import Avatar from "../assets/images/avatar_woman.png";
 import Btn_Enter from "../assets/images/btn_entrance.png";
@@ -7,9 +7,12 @@ import Btn_Create from "../assets/images/btn_create.png";
 import Header from "shared/Header";
 import Layout from "shared/Layout";
 import Time from "shared/Time";
+import Guideline from "components/common/GuideLine";
 
 const Home: React.FC = () => {
   const [progress, setProgress] = useState<number>(0);
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
 
   // 임의의 시간 간격으로 progress 값 증가
   React.useEffect(() => {
@@ -23,39 +26,53 @@ const Home: React.FC = () => {
     return () => clearInterval(interval);
   }, [progress]);
 
+  const handleButtonClick = () => {
+    setLoading(true);
+    setTimeout(() => {
+      setLoading(false);
+      navigate('/room/:roomId');
+    }, 6000);
+  };
+
   return (
     <Layout>
-      <Header
-        title="Home"
-        dis="운을 믿지 말고 요행을 기대 말고 나의 철저한 준비와 노력만을 믿어라"
-      >
-        <Profile src={Avatar} alt="Profile" />
-      </Header>
+      { loading ? (
+        <Guideline />
+      ) : (
+        <>
+          <Header
+            title="Home"
+            dis="운을 믿지 말고 요행을 기대 말고 나의 철저한 준비와 노력만을 믿어라"
+          >
+            <Profile src={Avatar} alt="Profile" />
+          </Header>
 
-      {/* 스터디룸 입장 및 생성 */}
-      <Study>
-        <SDiv>
-          <STitle>스터디룸 입장</STitle>
-          <SText>미리 설정한 스터디룸에서 공부를 시작하세요.</SText>
-          <StyleLink to="/room/:roomId">
-            <img src={Btn_Enter} alt="Enter the StudyRoom" />
-          </StyleLink>
-        </SDiv>
-        <SDiv>
-          <STitle>스터디룸 생성</STitle>
-          <SText>새로운 스터디룸을 만들어보세요.</SText>
-          <StyleLink to="/room">
-            <img src={Btn_Create} alt="Create a new StudyRoom" />
-          </StyleLink>
-        </SDiv>
-      </Study>
+          {/* 스터디룸 입장 및 생성 */}
+          <Study>
+            <SDiv>
+              <STitle>스터디룸 입장</STitle>
+              <SText>미리 설정한 스터디룸에서 공부를 시작하세요.</SText>
+              <Button onClick={handleButtonClick}>
+                <img src={Btn_Enter} alt="Enter the StudyRoom" />
+              </Button>
+            </SDiv>
+            <SDiv>
+              <STitle>스터디룸 생성</STitle>
+              <SText>새로운 스터디룸을 만들어보세요.</SText>
+              <StyleLink to="/room">
+                <img src={Btn_Create} alt="Create a new StudyRoom" />
+              </StyleLink>
+            </SDiv>
+          </Study>
 
-      {/* 오늘의 총 공부 시간 */}
-      <Time
-        title="오늘의 총 공부 시간"
-        totalTime="03 : 30 : 01"
-        goalTime="06 : 00 : 00"
-      ></Time>
+          {/* 오늘의 총 공부 시간 */}
+          <Time
+            title="오늘의 총 공부 시간"
+            totalTime="03 : 30 : 01"
+            goalTime="06 : 00 : 00"
+          ></Time>
+        </>
+      )}
     </Layout>
   );
 };
@@ -99,4 +116,12 @@ const StyleLink = styled(Link)`
   text-decoration: none;
   margin-bottom: 10px;
 `;
+
+const Button = styled.button`
+  border: none;
+  padding: 0;
+  background-color: transparent;
+  cursor: pointer;
+`;
+
 export default Home;

--- a/src/pages/StudyRoomSetting.tsx
+++ b/src/pages/StudyRoomSetting.tsx
@@ -5,9 +5,11 @@ import StudyType from "components/studySetting/StudyType";
 import StudyMate from "components/studySetting/StudyMate";
 import StudyHelper from "components/studySetting/StudyHelper";
 import DefaultSetting from "components/studySetting/DefaultSetting";
+import Guideline from "components/common/GuideLine";
 
 const StudyRoomSetting: React.FC = () => {
   const [selectedTab, setSelectedTab] = useState('1. 스터디룸 타입');
+  const [loading, setLoading] = useState(false);
 
   const handleTabSelect = (tab: string) => {
     setSelectedTab(tab);
@@ -15,17 +17,22 @@ const StudyRoomSetting: React.FC = () => {
 
   return (
     <Wrapper>
-      <SettingTab
-        tabs={['1. 스터디룸 타입', '2. 스터디 메이트', '3. 스터디 도우미', '4. 디폴트 설정']}
-        selectedTab={selectedTab}
-        onSelectTab={handleTabSelect}
-      />
+      { loading ? (
+        <Guideline />
+      ) : (
+        <>
+          <SettingTab
+            tabs={['1. 스터디룸 타입', '2. 스터디 메이트', '3. 스터디 도우미', '4. 디폴트 설정']}
+            selectedTab={selectedTab}
+            onSelectTab={handleTabSelect}
+          />
 
-      {selectedTab === '1. 스터디룸 타입' ? <StudyType setSelectedTab={setSelectedTab} /> 
-      : selectedTab === '2. 스터디 메이트' ? <StudyMate setSelectedTab={setSelectedTab} /> 
-      : selectedTab === '3. 스터디 도우미' ? <StudyHelper setSelectedTab={setSelectedTab} />
-      : <DefaultSetting setSelectedTab={setSelectedTab} />}
-
+          {selectedTab === '1. 스터디룸 타입' ? <StudyType setSelectedTab={setSelectedTab} /> 
+          : selectedTab === '2. 스터디 메이트' ? <StudyMate setSelectedTab={setSelectedTab} /> 
+          : selectedTab === '3. 스터디 도우미' ? <StudyHelper setSelectedTab={setSelectedTab} />
+          : <DefaultSetting setSelectedTab={setSelectedTab} setLoading={setLoading} />}
+        </>
+      )}
     </Wrapper>
   );
 };


### PR DESCRIPTION
## PR 타입
feat / ui 구현, fix

## 반영 브랜치
feat/#54 -> main
delete feat/#54

## 작업 내용
![image](https://github.com/StudyBuddyCorps/Front-end/assets/71203375/6ae3ec93-bc7f-44dd-852e-8da6125e48cb)
- WebRTC 사용
- 영상위 가이드라인 설정
- 디폴트 설정 `다음` 버튼 클릭 시 일정시간 대기 후 스터디룸으로 이동
- 대기 시간 동안 사용자 안내 컴포넌트 표시
- 테스트를 위한 대기 시간 임의 설정
- 카메라 권한을 활성화 해야 다음 버튼을 사용할 수 있도록 수정
- 사이드바 위로 보이도록 가이드라인에 z-index, position: absolute 설정
- 홈의 스터디룸 입장 버튼과 연결

## 리뷰 요구 사항 (선택)
